### PR TITLE
typing: Fix type annotation errors

### DIFF
--- a/src/moneymanager/controller/cli/cli_add_transaction_controller.py
+++ b/src/moneymanager/controller/cli/cli_add_transaction_controller.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
 
 class CliAddTransactionController(BaseController):
     def __init__(self, app: App) -> None:
-
         super().__init__(app)
         self.view = CliAddTransactionView()
         self.repository = self.app.database.transaction_repository

--- a/src/moneymanager/controller/cli/cli_add_transaction_controller.py
+++ b/src/moneymanager/controller/cli/cli_add_transaction_controller.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 class CliAddTransactionController(BaseController):
     def __init__(self, app: App) -> None:
+
         super().__init__(app)
         self.view = CliAddTransactionView()
         self.repository = self.app.database.transaction_repository

--- a/src/moneymanager/controller/cli/cli_manage_account_controller.py
+++ b/src/moneymanager/controller/cli/cli_manage_account_controller.py
@@ -60,7 +60,6 @@ class CliManageAccountController(BaseController):
 
         self._view.display_line_separator()
 
-        # TODO: handle invalid account
         try:  # Try exept for account with name (name) doesn't exist
             model = self._repository.select(name)
         except ValueError:

--- a/src/moneymanager/database/base_csv_repository.py
+++ b/src/moneymanager/database/base_csv_repository.py
@@ -14,7 +14,7 @@ from moneymanager.database.model.model import Model
 from moneymanager.database.repository.repository import Repository
 
 
-class BaseCsvRepository[ID](ABC, Repository[ID]):
+class BaseCsvRepository[T: Model, ID](ABC, Repository[T, ID]):
     """Abstract base class of a CSV repository.
 
     Extend this class to create a concrete CSV repository. The concrete class should
@@ -31,7 +31,7 @@ class BaseCsvRepository[ID](ABC, Repository[ID]):
 
 
     @dataclass
-    class ConcreteModel(Model[str]):
+    class ConcreteModel(Model[int]):
         id: int
         col1: str
         col2: int
@@ -45,7 +45,7 @@ class BaseCsvRepository[ID](ABC, Repository[ID]):
             return "id"
 
 
-    class ConcreteCsvRepository(BaseCsvRepository):
+    class ConcreteCsvRepository(BaseCsvRepository[ConcreteModel, int]):
         @property
         def filename(self):
             return "concrete.csv"
@@ -86,11 +86,11 @@ class BaseCsvRepository[ID](ABC, Repository[ID]):
 
     @property
     @abstractmethod
-    def model(self) -> type[Model[ID]]:
+    def model(self) -> type[T]:
         """Model class of the repository."""
 
     @override
-    def select(self, identifier: ID) -> Model[ID]:
+    def select(self, identifier: ID) -> T:
         with self._enter_reader() as reader:
             for row in reader:
                 if row[self.model.primary_field()] == identifier:
@@ -146,7 +146,7 @@ class BaseCsvRepository[ID](ABC, Repository[ID]):
             raise ValueError(f"Model with key {identifier} is not found.")
 
     @override
-    def select_all(self) -> list[Model[ID]]:
+    def select_all(self) -> list[T]:
         with self._enter_reader() as reader:
             return [self.model(**row) for row in reader]  # type: ignore
 

--- a/src/moneymanager/database/repository/account_repository.py
+++ b/src/moneymanager/database/repository/account_repository.py
@@ -4,7 +4,7 @@ from moneymanager.database.base_csv_repository import BaseCsvRepository
 from moneymanager.database.model.account import Account
 
 
-class AccountRepository(BaseCsvRepository):
+class AccountRepository(BaseCsvRepository[Account, str]):
     @property
     @override
     def filename(self) -> str:

--- a/src/moneymanager/database/repository/repository.py
+++ b/src/moneymanager/database/repository/repository.py
@@ -3,8 +3,8 @@ from typing import Protocol
 from moneymanager.database.model.model import Model
 
 
-class Repository[ID](Protocol):
-    def select(self, identifier: ID) -> Model[ID]:
+class Repository[T: Model, ID](Protocol):
+    def select(self, identifier: ID) -> T:
         """Selects an entry from the database.
 
         Parameters
@@ -24,7 +24,7 @@ class Repository[ID](Protocol):
         """
         ...
 
-    def insert(self, entity: Model[ID]) -> None:
+    def insert(self, entity: ID) -> None:
         """Inserts a new entry into the database.
 
         Parameters
@@ -39,7 +39,7 @@ class Repository[ID](Protocol):
         """
         ...
 
-    def update(self, identifier: ID, entity: Model[ID]) -> None:
+    def update(self, identifier: ID, entity: T) -> None:
         """Updates an entry in the database.
 
         Parameters
@@ -71,7 +71,7 @@ class Repository[ID](Protocol):
         """
         ...
 
-    def select_all(self) -> list[Model[ID]]:
+    def select_all(self) -> list[T]:
         """Selects all entries from the database.
 
         Returns


### PR DESCRIPTION
Type annotation errors are causing incorrect type annotations of `Model` by linters.

![image](https://github.com/user-attachments/assets/94ccd896-9b32-426e-8b7c-23c579eacdef)

These type errors are fixed in this commit.

![image](https://github.com/user-attachments/assets/271da947-5aac-4799-abda-589c1737d17f)



